### PR TITLE
Support for lex file and output path

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,17 @@
 var through = require('through2');
 var gutil = require('gulp-util');
 var PluginError = gutil.PluginError;
+
+var fs = require('fs');
+var ebnfParser = require('ebnf-parser');
+var lexParser  = require('lex-parser');
 var Parser = require('jison').Parser;
 
 const PLUGIN_NAME = 'gulp-jison';
 
 module.exports = function (options) {
     options = options || {};
+    options.jisonOptions = options.jisonOptions || {}
 
     return through.obj(function (file, enc, callback) {
         if (file.isNull()) {
@@ -21,8 +26,12 @@ module.exports = function (options) {
 
         if (file.isBuffer()) {
             try {
-                file.contents = new Buffer(new Parser(file.contents.toString(), options).generate());
-                file.path = gutil.replaceExtension(file.path, ".js");
+                var grammar = ebnfParser.parse(file.contents.toString());
+                if(options.lexFile)
+                  grammar.lex = lexParser.parse(fs.readFileSync(options.lexFile, { encoding: 'utf8' }));
+              
+                file.contents = new Buffer(new Parser(grammar, options.jisonOptions).generate());
+                file.path = options.outFile || gutil.replaceExtension(file.path, ".js");
                 this.push(file);
             } catch (error) {
                 this.emit('error', new PluginError(PLUGIN_NAME, error));

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "should": "~3.1.2"
   },
   "dependencies": {
+    "ebnf-parser": "^0.1.10",
+    "lex-parser": "^0.1.4",
     "jison": "~0.4.13",
     "through2": "~0.4.1",
     "gulp-util": "~2.2.14"


### PR DESCRIPTION
Seperated the Gulp options from the Jison options to add support for
reading a lex file and defining the output path in case the input name
doesn't match.

Now the grammar is properly constructed so that Jison is capable of
parsing tokens and generate a working parser and lexer with it.

**Options changed**
- lexFile: input path to a lex file, ie `tokens.jisonlex`
- outFile: output path of the result
- jisonOptions: options passed to `Jison`

**Note**
_Creation of the grammar is identical with the cli version of Jison._
