### PR TITLE
Accept json grammars

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var through = require('through2');
 var gutil = require('gulp-util');
 var PluginError = gutil.PluginError;
 var Generator = require('jison').Generator;
+var Parser = require('jison').Parser;
 
 const PLUGIN_NAME = 'gulp-jison';
 
@@ -21,7 +22,25 @@ module.exports = function (options) {
 
         if (file.isBuffer()) {
             try {
-                file.contents = new Buffer(new Generator(file.contents.toString(), options).generate());
+                var input = file.contents.toString();
+                var json = null;
+
+                try {
+                    // Will throw an error if the input is not JSON.
+                    json = JSON.parse(input);
+                } catch (err) {
+                    // JSON parsing failed, must be a Jison grammar.
+                    json = null;
+                } finally {
+                    if (json === null) {
+                        // Input is a Jison grammar.
+                        file.contents = new Buffer(new Generator(input, options).generate());
+                    } else {
+                        // Input is a JSON structure.
+                        file.contents = new Buffer(new Generator(json, options).generate());
+                    }
+                }
+
                 file.path = gutil.replaceExtension(file.path, ".js");
                 this.push(file);
             } catch (error) {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ var through = require('through2');
 var gutil = require('gulp-util');
 var PluginError = gutil.PluginError;
 var Generator = require('jison').Generator;
-var Parser = require('jison').Parser;
 
 const PLUGIN_NAME = 'gulp-jison';
 

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
   "devDependencies": {
     "ebnf-parser": "~0.1.10",
     "lex-parser": "~0.1.4",
-    "mocha": "~2.2.1",
-    "should": "~5.1.0"
+    "mocha": "~2.4.5",
+    "should": "~8.3.1"
   },
   "dependencies": {
-    "jison": "~0.4.17",
-    "through2": "~0.6.3",
-    "gulp-util": "~3.0.4"
+    "jison": "0.4.17",
+    "through2": "2.0.1",
+    "gulp-util": "3.0.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,11 +21,13 @@
   },
   "homepage": "https://github.com/matteckert/gulp-jison",
   "devDependencies": {
+    "ebnf-parser": "~0.1.10",
+    "lex-parser": "~0.1.4",
     "mocha": "~2.2.1",
     "should": "~5.1.0"
   },
   "dependencies": {
-    "jison": "~0.4.15",
+    "jison": "~0.4.17",
     "through2": "~0.6.3",
     "gulp-util": "~3.0.4"
   }

--- a/test/main.js
+++ b/test/main.js
@@ -4,6 +4,7 @@ var gulpJison = require('../');
 var gutil = require('gulp-util');
 var fs = require('fs');
 var path = require('path');
+var ebnfParser = require('ebnf-parser');
 require('mocha');
 
 var createVirtualFile = function (filename, contents) {
@@ -45,5 +46,23 @@ describe('gulp-jison', function() {
             })
             .write(createVirtualFile('calculator.jison', text));
     });
-});
 
+    it('should work with json', function (done) {
+        var options = {type: 'slr', moduleType: 'amd', moduleName: 'jsoncheck'};
+
+        var filepath = 'test/fixtures/calculator.jison';
+        var text = fs.readFileSync(filepath);
+        var expected = rawJison.Generator(text.toString(), options).generate();
+
+        // Generate JSON grammar from Jison grammar.
+        var json = JSON.stringify(ebnfParser.parse(text.toString()));
+
+        gulpJison(options)
+            .on('error', done)
+            .on('data', function(data) {
+                data.contents.toString().should.equal(expected);
+                done();
+            })
+            .write(createVirtualFile('calculator.json', new Buffer(json)));
+    });
+});


### PR DESCRIPTION
This pull request adds support for generating parsers from a grammar provided
in JSON format rather than just .jison format.

Since a .jison grammar will never be valid JSON value, the plugin now
checks if the input is JSON parseable, and if it is, treats it as JSON.
Otherwise it will revert to its previous behaviour.

I also updated the dependencies.
