### PR TITLE
Remove deprecated gulp-util dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var through = require('through2');
-var gutil = require('gulp-util');
-var PluginError = gutil.PluginError;
+var replaceExtension = require('replace-ext');
+var PluginError = require('plugin-error');
 var Generator = require('jison').Generator;
 
 const PLUGIN_NAME = 'gulp-jison';
@@ -22,7 +22,7 @@ module.exports = function (options) {
         if (file.isBuffer()) {
             try {
                 file.contents = new Buffer(new Generator(file.contents.toString(), options).generate());
-                file.path = gutil.replaceExtension(file.path, ".js");
+                file.path = replaceExtension(file.path, ".js");
                 this.push(file);
             } catch (error) {
                 this.emit('error', new PluginError(PLUGIN_NAME, error));

--- a/package.json
+++ b/package.json
@@ -22,11 +22,13 @@
   "homepage": "https://github.com/matteckert/gulp-jison",
   "devDependencies": {
     "mocha": "~2.2.1",
-    "should": "~5.1.0"
+    "should": "~5.1.0",
+    "vinyl": "~2.1.0"
   },
   "dependencies": {
     "jison": "~0.4.15",
-    "through2": "~0.6.3",
-    "gulp-util": "~3.0.4"
+    "plugin-error": "~1.0.0",
+    "replace-ext": "~1.0.0",
+    "through2": "~0.6.3"
   }
 }

--- a/test/main.js
+++ b/test/main.js
@@ -1,13 +1,13 @@
 var should = require('should');
 var rawJison = require('jison');
 var gulpJison = require('../');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 var fs = require('fs');
 var path = require('path');
 require('mocha');
 
 var createVirtualFile = function (filename, contents) {
-    return new gutil.File({
+    return new Vinyl({
         path: path.join(__dirname, 'fixtures', filename),
         base: path.join(__dirname, 'fixtures'),
         cwd: process.cwd(),


### PR DESCRIPTION
According to https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5 gulp-util is deprecated now. Please consider updating dependencies.